### PR TITLE
Check for nil before comparison

### DIFF
--- a/lua/autorun/client/cl_buy_notif_autorun.lua
+++ b/lua/autorun/client/cl_buy_notif_autorun.lua
@@ -67,7 +67,7 @@ net.Receive("TEBN_ItemBought", function()
 
 	if is_item then
 		for _, item in pairs(tbl) do
-			if TTT2 and (item.id == equipment or item.oldId == tonumber(equipment)) or not TTT2 and item.id == tonumber(equipment) then
+			if TTT2 and (item.id == equipment or item.oldId and item.oldId == tonumber(equipment)) or not TTT2 and item.id == tonumber(equipment) then
 				itemObject = item
 				break
 			end


### PR DESCRIPTION
This should easily fix the problem with wrong items being shown. Fixes #9 by checking for nil before comparing to a number. 

![grafik](https://github.com/saibotk/ttt-team-buy-notifications/assets/72046466/9216f148-eee3-4b5c-a5aa-afe151f7b051)
